### PR TITLE
Remove use of environmental file

### DIFF
--- a/dmpy/client.py
+++ b/dmpy/client.py
@@ -4,8 +4,8 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
+import os
 import requests
-from dotenv import get_key, load_dotenv, set_key
 from requests_toolbelt.multipart.encoder import (
     MultipartEncoder,
     MultipartEncoderMonitor,
@@ -18,14 +18,13 @@ log = logging.getLogger(__name__)
 
 
 class Dmpy:
-    def __init__(self, env_file: str = ".dmpy.env"):
-        self.env = env_file
-        load_dotenv(self.env)
-        self.url = get_key(self.env, "DMP_URL")
-        self.pubkey = get_key(self.env, "DMP_PUBLIC_KEY")
-        self.signature = get_key(self.env, "DMP_SIGNATURE")
-        self.last_created = int(get_key(self.env, "DMP_ACCESS_TOKEN_GEN_TIME"))
-        self.access_token = get_key(self.env, "DMP_ACCESS_TOKEN")
+    def __init__(self):
+        self.url = os.getenv("DMP_URL")
+        self.pubkey = os.getenv("DMP_PUBLIC_KEY")
+        self.signature = os.getenv("DMP_SIGNATURE")
+        # Store these in memory rather than file
+        self.access_token = os.getenv("DMP_ACCESS_TOKEN")
+        self.last_created = int(os.getenv("DMP_ACCESS_TOKEN_GEN_TIME"))
 
     def __access_token(self) -> str:
         """Obtain (or refresh) an access token."""
@@ -50,9 +49,9 @@ class Dmpy:
             except Exception:
                 log.error("Exception:", exc_info=True)
 
-            set_key(self.env, "DMP_ACCESS_TOKEN", access_token)
             self.access_token = access_token
-            set_key(self.env, "DMP_ACCESS_TOKEN_GEN_TIME", str(now))
+            os.environ["DMP_ACCESS_TOKEN"] = access_token
+            os.environ["DMP_ACCESS_TOKEN_GEN_TIME"] = str(now)
         return self.access_token
 
     def upload(self, payload: FileUploadPayload) -> bool:

--- a/dmpy/client.py
+++ b/dmpy/client.py
@@ -18,8 +18,8 @@ log = logging.getLogger(__name__)
 
 
 class Dmpy:
-    def __init__(self):
-        self.env = ".dmpy.env"
+    def __init__(self, env_file: str = ".dmpy.env"):
+        self.env = env_file
         load_dotenv(self.env)
         self.url = get_key(self.env, "DMP_URL")
         self.pubkey = get_key(self.env, "DMP_PUBLIC_KEY")

--- a/dmpy/core/payloads.py
+++ b/dmpy/core/payloads.py
@@ -20,7 +20,7 @@ class FileUploadPayload:
     content_hash: str
     # Default value used from .env or can be overridden
     # by assigning data to this varaible on class creation.
-    study_id: str = os.environ.get("DMP_STUDY_ID", None)
+    study_id: str = os.getenv("DMP_STUDY_ID")
 
     def variables(self) -> Dict:
         """Dumps variables in a format suitable for DMP API,

--- a/dmpy/core/payloads.py
+++ b/dmpy/core/payloads.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict
 
-from dotenv import get_key
+import os
 
 from .utils import read_text_resource
 
@@ -20,7 +20,7 @@ class FileUploadPayload:
     content_hash: str
     # Default value used from .env or can be overridden
     # by assigning data to this varaible on class creation.
-    study_id: str = get_key(".dmpy.env", "DMP_STUDY_ID")
+    study_id: str = os.environ.get("DMP_STUDY_ID", None)
 
     def variables(self) -> Dict:
         """Dumps variables in a format suitable for DMP API,

--- a/poetry.lock
+++ b/poetry.lock
@@ -423,17 +423,6 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
-name = "python-dotenv"
-version = "0.15.0"
-description = "Add .env support to your django/flask apps in development and deployments"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.extras]
-cli = ["click (>=5.0)"]
-
-[[package]]
 name = "pytz"
 version = "2021.1"
 description = "World timezone definitions, modern and historical"
@@ -574,7 +563,7 @@ cli = ["colorama", "pandas"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "bf320d92f537f0932192805cf632150b18ac3e1710139749a9b773735d5c9e7f"
+content-hash = "2223e5547100500aa32d7af903c4d535df5f0064c89fda56f77c2aba4c459e46"
 
 [metadata.files]
 appdirs = [
@@ -765,10 +754,6 @@ pytest = [
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
-]
-python-dotenv = [
-    {file = "python-dotenv-0.15.0.tar.gz", hash = "sha256:587825ed60b1711daea4832cf37524dfd404325b7db5e25ebe88c495c9f807a0"},
-    {file = "python_dotenv-0.15.0-py2.py3-none-any.whl", hash = "sha256:0c8d1b80d1a1e91717ea7d526178e3882732420b03f08afea0406db6402e220e"},
 ]
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ python = "^3.8"
 # Client specific dependencies
 requests = "^2.24.0"
 requests_toolbelt = "^0.9.1"
-python-dotenv = "^0.15.0"
 # Made optional as only used by CLI.
 colorama =  {version = "^0.4.4", optional = true, extras = ["cli"]}
 pandas =  {version = "^1.1.4", optional = true, extras = ["cli"]}


### PR DESCRIPTION
## Problem

As the path to the env file was hard-coded within the client package, DMPY environment variables would not be picked up as the `dmpy.env` file was not found. Notably, we store `access_token` and `access_token_gen_time` in the env_file, however, these are only used internally within `dmpy.client`. As such, I have refactored client to not depend on a env file -- the required variables should simply be loaded into the environment prior to use, and `access_token` and `access_token_gen_time` are stored in memory and not in e.g., `dmpy.env`. This has some advantages: (1) when a docker container is killed the environment will be cleared and so these will be regenerated; (2) they are stored in memory so less open to attack.

## To Test

A code review would suffice given changes are minimal,  both in this branch and in [this commit where this branch is used](https://github.com/ideafast/middleware-services/commit/1dad0d9e655046bd1a6e01d4d38fc7de53159a35). Once merged, I'll tag master and use the correct version in the middleware.