### PR TITLE
Specify default value for last_created

### DIFF
--- a/dmpy/client.py
+++ b/dmpy/client.py
@@ -24,7 +24,7 @@ class Dmpy:
         self.signature = os.getenv("DMP_SIGNATURE")
         # Store these in memory rather than file
         self.access_token = os.getenv("DMP_ACCESS_TOKEN")
-        self.last_created = int(os.getenv("DMP_ACCESS_TOKEN_GEN_TIME"))
+        self.last_created = int(os.getenv("DMP_ACCESS_TOKEN_GEN_TIME", 0))
 
     def __access_token(self) -> str:
         """Obtain (or refresh) an access token."""


### PR DESCRIPTION
Ensures this does not need initially defined in an .env file. This was an oversight in #4 as the default value was stored in the environmental variable.