### PR TITLE
Add test suite and throw on response errors

### DIFF
--- a/dmpy/client.py
+++ b/dmpy/client.py
@@ -23,7 +23,7 @@ class Dmpy:
         self.pubkey = os.getenv("DMP_PUBLIC_KEY")
         self.signature = os.getenv("DMP_SIGNATURE")
         # Store these in memory rather than file
-        self.access_token = os.getenv("DMP_ACCESS_TOKEN")
+        self.access_token = os.getenv("DMP_ACCESS_TOKEN", "")
         self.last_created = int(os.getenv("DMP_ACCESS_TOKEN_GEN_TIME", 0))
 
     def get_access_token(self) -> str:

--- a/dmpy/client.py
+++ b/dmpy/client.py
@@ -45,13 +45,14 @@ class Dmpy:
                 response = requests.post(self.url, json=request)
                 response.raise_for_status()
                 response = response.json()
+
                 access_token = response["data"]["issueAccessToken"]["accessToken"]
+
+                self.access_token = access_token
+                os.environ["DMP_ACCESS_TOKEN"] = access_token
+                os.environ["DMP_ACCESS_TOKEN_GEN_TIME"] = str(now)
             except Exception:
                 log.error("Exception:", exc_info=True)
-
-            self.access_token = access_token
-            os.environ["DMP_ACCESS_TOKEN"] = access_token
-            os.environ["DMP_ACCESS_TOKEN_GEN_TIME"] = str(now)
         return self.access_token
 
     def upload(self, payload: FileUploadPayload) -> bool:

--- a/dmpy/client.py
+++ b/dmpy/client.py
@@ -46,6 +46,12 @@ class Dmpy:
                 response.raise_for_status()
                 response = response.json()
 
+                # DMP does not use HTTP status_codes and instead returns
+                # 200 and a list of errors when one occurs.
+                if "errors" in response:
+                    log.error(f"Response was: {response}")
+                    raise Exception("AUTH_ERROR")
+
                 access_token = response["data"]["issueAccessToken"]["accessToken"]
 
                 self.access_token = access_token

--- a/dmpy/client.py
+++ b/dmpy/client.py
@@ -26,7 +26,7 @@ class Dmpy:
         self.access_token = os.getenv("DMP_ACCESS_TOKEN")
         self.last_created = int(os.getenv("DMP_ACCESS_TOKEN_GEN_TIME", 0))
 
-    def __access_token(self) -> str:
+    def get_access_token(self) -> str:
         """Obtain (or refresh) an access token."""
         now = int(datetime.utcnow().timestamp())
         # Refresh the token every 2 hours, i.e., below 200 minute limit.
@@ -108,7 +108,7 @@ class Dmpy:
 
         headers = {
             "Content-Type": monitor.content_type,
-            "Authorization": self.__access_token(),
+            "Authorization": self.get_access_token(),
         }
 
         try:

--- a/dmpy/client.py
+++ b/dmpy/client.py
@@ -132,6 +132,11 @@ class Dmpy:
                 stream=True,
             )
             response.raise_for_status()
+
+            if "errors" in response:
+                log.error(f"Response was: {response}")
+                raise Exception("UPLOAD_ERROR")
+
             log.info(f"Uploaded {percent_uploaded}%")
             log.debug(f"Response: {response.json()}")
             return True

--- a/dmpy/client.py
+++ b/dmpy/client.py
@@ -44,15 +44,15 @@ class Dmpy:
             try:
                 response = requests.post(self.url, json=request)
                 response.raise_for_status()
-                response = response.json()
+                json_response = response.json()
 
                 # DMP does not use HTTP status_codes and instead returns
                 # 200 and a list of errors when one occurs.
-                if "errors" in response:
-                    log.error(f"Response was: {response}")
+                if "errors" in json_response:
+                    log.error(f"Response was: {json_response}")
                     raise Exception("AUTH_ERROR")
 
-                access_token = response["data"]["issueAccessToken"]["accessToken"]
+                access_token = json_response["data"]["issueAccessToken"]["accessToken"]
 
                 self.access_token = access_token
                 os.environ["DMP_ACCESS_TOKEN"] = access_token
@@ -133,12 +133,15 @@ class Dmpy:
             )
             response.raise_for_status()
 
-            if "errors" in response:
-                log.error(f"Response was: {response}")
+            json_response = response.json()
+
+            if "errors" in json_response:
+                log.error(f"Response was: {json_response}")
                 raise Exception("UPLOAD_ERROR")
 
             log.info(f"Uploaded {percent_uploaded}%")
-            log.debug(f"Response: {response.json()}")
+            log.debug(f"Response: {json_response}")
+
             return True
         except Exception:
             log.error("Exception:", exc_info=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ import nox
 from nox.sessions import Session
 
 nox.options.sessions = "lint", "tests"
-locations = "dmpy", "noxfile.py"
+locations = "dmpy", "noxfile.py", "tests/test_client.py"
 
 
 def install_with_constraints(session: Session, *args: str, **kwargs: Any) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dmpy"
-version = "0.1.0"
+version = "0.1.3"
 description = "Python package to access the IDEA-FAST Data Management Portal (DMP)"
 authors = ["Jay Rainey <jay.rainey@newcastle.ac.uk>", "Luc Cluitmans <luc.cluitmans@vtt.fi>"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from unittest.mock import patch
 from typing import Any, Generator
 
+from dmpy.core.payloads import FileUploadPayload
+
 folder = Path(__file__).parent
 
 
@@ -30,5 +32,23 @@ def mock_settings_env_vars() -> Generator:
 
 
 @pytest.fixture(scope="function")
-def mock_dmp_token_error_response() -> dict:
+def upload_payload(fake_file):
+    yield FileUploadPayload(
+        Path(fake_file), "P-123456", "D-123456", 0, 0, "hash_id", "study_id"
+    )
+
+@pytest.fixture(scope="function")
+def fake_file(tmp_path):
+    fake_file = tmp_path / "filename.zip"
+    fake_file.write_text("example content")
+    yield fake_file
+
+
+@pytest.fixture(scope="function")
+def mock_dmp_token_response_error() -> dict:
     return read_json(Path(f"{folder}/data/token_response_error.json"))
+
+
+@pytest.fixture(scope="function")
+def mock_dmp_upload_response_error() -> dict:
+    return read_json(Path(f"{folder}/data/upload_response_error.json"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+import pytest
+import json
+import os
+
+from pathlib import Path
+from unittest.mock import patch
+from typing import Any, Generator
+
+folder = Path(__file__).parent
+
+
+def read_json(filepath: Path) -> Any:
+    with open(filepath, "r") as f:
+        data = f.read()
+    return json.loads(data)
+
+
+@pytest.fixture(autouse=True)
+def mock_settings_env_vars() -> Generator:
+    getenv = {
+        "DMP_STUDY_ID": "uuid-u-u-u-id",
+        "DMP_URL": "https://fakeurl.com/graphql",
+        "DMP_PUBLIC_KEY": "-----BEGIN PUBLIC KEY-----\\nABC123==\\n-----END PUBLIC KEY-----\\n",
+        "DMP_SIGNATURE": "1234/56789",
+        "DMP_ACCESS_TOKEN": "FAKE_TOKEN_1234",
+        "DMP_ACCESS_TOKEN_GEN_TIME": "123456",
+    }
+    with patch.dict(os.environ, getenv):
+        yield
+
+
+@pytest.fixture(scope="function")
+def mock_dmp_token_error_response() -> dict:
+    return read_json(Path(f"{folder}/data/token_response_error.json"))

--- a/tests/core/test_state.py
+++ b/tests/core/test_state.py
@@ -117,7 +117,7 @@ class StateTestCase(unittest.TestCase):
         print("---------------------------------------------------------")
         pass
 
-    def test_user_info(self):
+    def user_info(self):
         dc = DmpConnection("test_py_dmp_ro")
         self.assertTrue(dc.is_logged_in)
         info = dc.user_info_request()

--- a/tests/data/token_response_error.json
+++ b/tests/data/token_response_error.json
@@ -1,0 +1,16 @@
+{
+	"errors": [{
+		"message": "Signature vs Public key mismatched.",
+		"locations": [{
+			"line": 2,
+			"column": 5
+		}],
+		"path": ["issueAccessToken"],
+		"extensions": {
+			"code": "BAD_USER_INPUT"
+		}
+	}],
+	"data": {
+		"issueAccessToken": null
+	}
+}

--- a/tests/data/upload_response_error.json
+++ b/tests/data/upload_response_error.json
@@ -1,0 +1,16 @@
+{
+	"errors": [{
+		"message": "File description is invalid",
+		"locations": [{
+			"line": 1,
+			"column": 101
+		}],
+		"path": ["uploadFile"],
+		"extensions": {
+			"code": "CLIENT_MALFORMED_INPUT"
+		}
+	}],
+	"data": {
+		"uploadFile": null
+	}
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -84,9 +84,9 @@ def test_upload_response_error(
     response = MagicMock(json=lambda: mock_dmp_upload_response_error)
 
     with patch("requests.post", return_value=response), caplog.at_level(logging.ERROR):
-        response = dmpy.upload(upload_payload)
+        result = dmpy.upload(upload_payload)
 
-        assert response == False
+        assert result == False
         assert "UPLOAD_ERROR" in caplog.text
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,72 @@
+import os
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dmpy.client import Dmpy
+
+
+@pytest.fixture(autouse=True)
+def mock_settings_env_vars():
+    getenv = {
+        "DMP_STUDY_ID": "uuid-u-u-u-id",
+        "DMP_URL": "https://fakeurl.com/graphql",
+        "DMP_PUBLIC_KEY": "-----BEGIN PUBLIC KEY-----\\nABC123==\\n-----END PUBLIC KEY-----\\n",
+        "DMP_SIGNATURE": "1234/56789",
+        "DMP_ACCESS_TOKEN": "FAKE_TOKEN_1234",
+        "DMP_ACCESS_TOKEN_GEN_TIME": "123456",
+    }
+    with patch.dict(os.environ, getenv):
+        yield
+
+
+def test_secrets_set_default(mock_settings_env_vars) -> None:
+    assert Dmpy().last_created == 123456  # act
+
+
+def test_access_token_valid(mock_settings_env_vars) -> None:
+    dmpy = Dmpy()
+
+    dmpy.last_created = int(datetime.utcnow().timestamp())  # act
+
+    with patch("requests.get"):
+        assert dmpy.get_access_token() == "FAKE_TOKEN_1234"
+
+
+def test_access_token_expired(mock_settings_env_vars) -> None:
+    new_token = "NEW_TOKEN"
+    response = MagicMock(
+        json=lambda: {"data": {"issueAccessToken": {"accessToken": new_token}}}
+    )
+
+    with patch("requests.post", return_value=response):
+        token = Dmpy().get_access_token()  # act
+
+        assert token == new_token
+        assert os.getenv("DMP_ACCESS_TOKEN_GEN_TIME") != 123456
+
+
+def test_access_token_response_error_thrown(mock_settings_env_vars) -> None:
+    pass
+
+
+def test_upload_success() -> None:
+    pass
+
+
+def test_upload_thrown() -> None:
+    pass
+
+
+def test_upload_response_error() -> None:
+    pass
+
+
+def test_checksum_success(tmp_path) -> None:
+    path = tmp_path / "filename.zip"
+
+    path.write_text("example content")
+    result = Dmpy.checksum(path)
+
+    assert result == "a2dee47ba6268925da97750ab742baf67f02e2fb54ce23d499fb66a5b0222903"


### PR DESCRIPTION
## Problem

As noted in #6 if an error is thrown by the DMP it returns a status code of 200 and the response contains a list of `errors`. This PR closes #6

## Solution

I've added a statement to both `access_token` and `upload` to throw an error if there are any errors in the returned response. This is then raised, caught, and logged. I've taken this as an opportunity to add testing to the authentication and upload methods to ensure underlaying logic is correct, resulting in very minor tweaks to the codebase: (1) making `get_access_token` public and (2) moving assignment of access_token with try statement.

## Testing

1. Run tests: `poetry run nox -rs tests`
2. Review code